### PR TITLE
Remove last use of `Array.from` in `git-view`

### DIFF
--- a/lib/git-view.js
+++ b/lib/git-view.js
@@ -1,6 +1,5 @@
 /*
  * decaffeinate suggestions:
- * DS101: Remove unnecessary use of Array.from
  * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
  */
 import _ from 'underscore-plus';
@@ -124,9 +123,7 @@ export default class GitView {
   }
 
   getRepositoryForActiveItem() {
-    const [rootDir] = Array.from(
-      atom.project.relativizePath(this.getActiveItemPath())
-    );
+    const [rootDir] = atom.project.relativizePath(this.getActiveItemPath());
     const rootDirIndex = atom.project.getPaths().indexOf(rootDir);
     if (rootDirIndex >= 0) {
       return atom.project.getRepositories()[rootDirIndex];


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

`relativePath` will always return an array so Array.from is redundant: https://github.com/atom/atom/blob/master/src/project.js#L604

Removed suggestion in top comment, but the link might still be helpful so kept that

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

Possibly outdates https://github.com/atom/status-bar/pull/236 a little bit
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
